### PR TITLE
fix: email is a rich text error

### DIFF
--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -25,7 +25,13 @@ export default async (req, res) => {
           ],
         },
         Email: {
-          email,
+          rich_text: [
+            {
+              text: {
+                content: email,
+              },
+            },
+          ],
         },
         Subject: {
           rich_text: [


### PR DESCRIPTION
Fix the notion error "email is expected to be rich text"