### PR TITLE
fix: replace broken VS Code badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vscode-portfolio
-[![Open is Visual Studio Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/itsnitinr/vscode-portfolio)
+[![Open is Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://vscode.dev/github/itsnitinr/vscode-portfolio)
 
 A Visual Studio Code themed developer portfolio website built with Next.js and deployed on Vercel.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # vscode-portfolio
-[![Open is Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://vscode.dev/github/itsnitinr/vscode-portfolio)
+[![Open in Visual Studio Code](https://img.shields.io/static/v1?logo=visualstudiocode&label=&message=Open%20in%20Visual%20Studio%20Code&labelColor=2c2c32&color=007acc&logoColor=007acc)](https://vscode.dev/github/itsnitinr/vscode-portfolio)
 
 A Visual Studio Code themed developer portfolio website built with Next.js and deployed on Vercel.
 


### PR DESCRIPTION
**Summary**

Replaced the broken VS Code badge URL in the README with a working alternative using Shields.io and the latest vscode.dev/github/... format.

**Changes**
Fixed broken badge image URL
Updated repository link to the newer VS Code web URL format
Corrected badge text from Open is Visual Studio Code to Open in Visual Studio Code

**Result**
The badge now renders correctly and opens the repository directly in VS Code for the web.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Visual Studio Code quick-open badge: replaced the dynamic badge with a static shields.io badge, corrected the label to "Open in Visual Studio Code", and updated the link to the VS Code web editor.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/itsnitinr/vscode-portfolio/pull/33)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->